### PR TITLE
Add some missing translations

### DIFF
--- a/translation.json
+++ b/translation.json
@@ -235,5 +235,6 @@
   "Pending to claim": "",
   "Preview url": "",
   "Show Today TOTAL, forecast and so on as": "",
-  "All Together": ""
+  "All Together": "",
+  "Select...": ""
 }


### PR DESCRIPTION
Add some missing words / sentences that were causing some pages to be partially translated.

This pages are:
- Tracker
- Axies
- Payments
- Share
- Settings
- Details

And also the page footer is partially translated.
